### PR TITLE
Add local setup instructions for webapp and database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# seshat
+# Seshat: Global History Databank
 
-This is the beginning of the Seshat Project code.
-I will keep my notes here.
-Just added the branch to add sections and subsections.
-Part of the job is done in the utils and we need to commit the changes to the updated templates and views as well later.
+[Seshat](http://seshat-db.com/) was founded in 2011 to bring together the most current and comprehensive body of knowledge about human history in one place.
 
-### Switching to Qing for now.
+This repo contains the necessary Django Python code to host the [Seshat](http://seshat-db.com/) website and interact with the backend PostgreSQL database.
+

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -31,7 +31,10 @@ This page instructs software engineers how to get started working with the Djang
             ```
         - Open a new terminal
         </details>
-    - Check the installation works with `psql postgres` and do `\l` to see Owner username
+    - Open PostgreSQL with:
+        ```
+            psql postgres
+        ```
     - In psql, create a default superuser called "postgres", which is needed to restore the Seshat database from backup:
         ```
             CREATE USER postgres SUPERUSER;

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -58,10 +58,22 @@ This page instructs software engineers how to get started working with the Djang
         ```
 
 8. Create a config with your database info for Django
+    - Within the repo, create a file called `seshat/settings/.env` with the db connection vars
+    - For example:
+        ```
+            NAME=<seshat_db_name>
+            USER=postgres
+            HOST=localhost
+            PORT=5432
+        ```
+    - The presence of this file will ensure Django connects to your local database
 
-10. Create stuff in settings/base.py
+9. Run Django
+    ```
+        python manage.py runserver
+    ```
 
-11. `python manage.py runserver`
+10. The webapp should be visible in a browser at http://127.0.0.1:8000/
 
 
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,67 @@
+# Setup instructions
+
+This page instructs software engineers how to get started working with the Django codebase and PostgreSQL database.
+
+## Local setup
+
+1. Ensure you have a working installation of Python 3
+
+2. Set up a virtual environment for the project using e.g. venv or conda
+    - Note: The application has been tested with Python **3.8.13**
+    - Example:
+        ```
+            conda create --name seshat38 python=3.8.13
+            conda activate seshat38
+        ```
+
+3. Create a fork of the GitHub repo with all branches: https://github.com/MajidBenam/seshat
+
+4. Clone your fork to your local machine
+
+5. Ensure you have a working installation of PostgreSQL **version 12**
+    - <details><summary>Example instructions for macOS</summary>
+
+        - `brew install postgres@12`
+        - `brew services start postgresql@12`
+        - Update `~/.zshrc` (or equivalent for your terminal) with:
+            ```
+                export PATH="/opt/homebrew/opt/postgresql@12/bin:$PATH"
+                export LDFLAGS="-L/opt/homebrew/opt/postgresql@12/lib"
+                export CPPFLAGS="-I/opt/homebrew/opt/postgresql@12/include"
+            ```
+        - Open a new terminal
+        </details>
+    - Check the installation works with `psql postgres` and do `\l` to see Owner username
+    - In psql, create a default superuser called "postgres", which is needed to restore the Seshat database from backup:
+        ```
+            CREATE USER postgres SUPERUSER;
+        ```
+
+6. After PostgreSQL is installed, install the Python packages in your environment (some packages have psql as a dependency). From the top level of the `seshat` repo:
+    ```
+        pip install -r requirements.txt
+    ```
+
+7. Restore Seshat database from dump:
+    - Note: you'll need a dump file of the Seshat database, which can be provided by one of the current developers
+        ```
+        createdb -U postgres <seshat_db_name>
+
+        pg_restore -U postgres -d <seshat_db_name> /path/to/file.dump
+        ```
+    - Connect to the new test database to make sure things are in order
+        ```
+            psql -U postgres -d <seshat_db_name>
+        ```
+
+8. Create a config with your database info for Django
+
+10. Create stuff in settings/base.py
+
+11. `python manage.py runserver`
+
+
+
+## Production setup (AWS)
+
+_TODO_

--- a/manage.py
+++ b/manage.py
@@ -6,12 +6,12 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    if os.path.exists(".env"):
-        os.environ.setdefault('DJANGO_SETTINGS_MODULE',
+    # if os.path.exists(".env"):
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE',
                               'seshat.settings.local')
-    else:
-        os.environ.setdefault('DJANGO_SETTINGS_MODULE',
-                              'seshat.settings.production')
+    # else:
+    #     os.environ.setdefault('DJANGO_SETTINGS_MODULE',
+    #                           'seshat.settings.production')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/manage.py
+++ b/manage.py
@@ -2,16 +2,18 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
+from pathlib import Path
 
 
 def main():
     """Run administrative tasks."""
-    # if os.path.exists(".env"):
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE',
+    local_env_path = str(Path.cwd()) + "/seshat/settings/.env"
+    if os.path.exists(local_env_path):
+        os.environ.setdefault('DJANGO_SETTINGS_MODULE',
                               'seshat.settings.local')
-    # else:
-    #     os.environ.setdefault('DJANGO_SETTINGS_MODULE',
-    #                           'seshat.settings.production')
+    else:
+        os.environ.setdefault('DJANGO_SETTINGS_MODULE',
+                              'seshat.settings.production')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 asgiref==3.5.0
-backports.zoneinfo==0.2.1
 bibtexparser==1.3.0
 certifi==2021.10.8
 cffi==1.15.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ django-allauth==0.51.0
 django-cors-headers==3.11.0
 django-crispy-forms==1.14.0
 django-debug-toolbar==3.2.4
+django-environ==0.11.2
 django-filter==21.1
 django-heroku==0.3.1
 django-mathfilters==1.0.0

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -39,10 +39,10 @@ SECRET_KEY = config(
 
 DEBUG = config("DEBUG", default=True, cast=bool)
 
-# if DEBUG:
-#     MY_CURRENT_SERVER = "http://127.0.0.1:8000"
-# else:
-#     MY_CURRENT_SERVER = "https://www.majidbenam.com"
+if DEBUG:
+    MY_CURRENT_SERVER = "http://127.0.0.1:8000"
+else:
+    MY_CURRENT_SERVER = "https://www.majidbenam.com"
 
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="127.0.0.1,localhost", cast=Csv())
 # ALLOWED_HOSTS = ['seshatdb.herokuapp.com', '127.0.0.1',

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -267,12 +267,13 @@ USE_TZ = True
 LOCALE_PATHS = [BASE_DIR / "locale"]
 
 # Email config BACKUP:
-# EMAIL_FROM_USER = config('EMAIL_FROM_USER')
-# EMAIL_HOST = config('EMAIL_HOST')
-# EMAIL_HOST_USER = config('EMAIL_HOST_USER')
-# EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
-# EMAIL_USE_TLS = True
-# EMAIL_PORT = 587
+if not os.path.exists(local_env_path):
+    EMAIL_FROM_USER = config('EMAIL_FROM_USER')
+    EMAIL_HOST = config('EMAIL_HOST')
+    EMAIL_HOST_USER = config('EMAIL_HOST_USER')
+    EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
+    EMAIL_USE_TLS = True
+    EMAIL_PORT = 587
 
 ######EMAIL_CONFIRMATION_BRANCH is the keyword that needs to be searched
 # EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -44,7 +44,7 @@ if DEBUG:
 else:
     MY_CURRENT_SERVER = "https://www.majidbenam.com"
 
-# ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="127.0.0.1,localhost", cast=Csv())
+#ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="127.0.0.1,localhost", cast=Csv())
 ALLOWED_HOSTS = ['seshatdb.herokuapp.com', '127.0.0.1',
                  'majidbenam.com', 'www.majidbenam.com', 'https://majidbenam.com']
 

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -29,16 +29,17 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = config(
     "SECRET_KEY", default="django-insecure$seshat.settings.local")
 
-DEBUG = config("DEBUG", default=True, cast=bool)
+# DEBUG = config("DEBUG", default=True, cast=bool)
+DEBUG = True
 
-if DEBUG:
-    MY_CURRENT_SERVER = "http://127.0.0.1:8000"
-else:
-    MY_CURRENT_SERVER = "https://www.majidbenam.com"
+# if DEBUG:
+#     MY_CURRENT_SERVER = "http://127.0.0.1:8000"
+# else:
+#     MY_CURRENT_SERVER = "https://www.majidbenam.com"
 
-#ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="127.0.0.1,localhost", cast=Csv())
-ALLOWED_HOSTS = ['seshatdb.herokuapp.com', '127.0.0.1',
-                 'majidbenam.com', 'www.majidbenam.com', 'https://majidbenam.com']
+ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="127.0.0.1,localhost", cast=Csv())
+# ALLOWED_HOSTS = ['seshatdb.herokuapp.com', '127.0.0.1',
+#                  'majidbenam.com', 'www.majidbenam.com', 'https://majidbenam.com']
 
 
 INSTALLED_APPS = [

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -44,9 +44,9 @@ if DEBUG:
 else:
     MY_CURRENT_SERVER = "https://www.majidbenam.com"
 
-ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="127.0.0.1,localhost", cast=Csv())
-# ALLOWED_HOSTS = ['seshatdb.herokuapp.com', '127.0.0.1',
-#                  'majidbenam.com', 'www.majidbenam.com', 'https://majidbenam.com']
+# ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="127.0.0.1,localhost", cast=Csv())
+ALLOWED_HOSTS = ['seshatdb.herokuapp.com', '127.0.0.1',
+                 'majidbenam.com', 'www.majidbenam.com', 'https://majidbenam.com']
 
 
 INSTALLED_APPS = [

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -22,6 +22,9 @@ MESSAGE_TAGS = {
         messages.ERROR: 'alert-danger',
 }
 
+from pathlib import Path
+local_env_path = str(Path.cwd()) + "/seshat/settings/.env"
+
 # base_dir is calculated based on this file (base.py) and then goes to parents above.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -195,15 +198,30 @@ TEMPLATES = [
 # DATABASES['default'].update(db_from_env)
 
 # Qing data database
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': env('NAME'),
-        'USER': env('USER'),
-        'HOST': env('HOST'),
-        'PORT': 5432,
+
+# Use local db if .env present
+if os.path.exists(local_env_path):
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': env('NAME'),
+            'USER': env('USER'),
+            'HOST': env('HOST'),
+            'PORT': env('PORT'),
+        }
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': config('DB_NAME'),
+            'USER': config('DB_USER'),
+            'PASSWORD': config('DB_PASSWORD'),
+            'HOST': 'localhost',
+            'PORT': 5432,
+        }
+    }
+
 #DATABASES['default'] = dj_database_url.config(conn_max_age=600)
 
 # ==============================================================================

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -193,9 +193,9 @@ TEMPLATES = [
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': config('DB_NAME'),
-        'USER': config('DB_USER'),
-        'PASSWORD': config('DB_PASSWORD'),
+        'NAME': 'seshat_oct5',
+        'USER': 'postgres',
+        # 'PASSWORD': config('DB_PASSWORD'),
         'HOST': 'localhost',
         'PORT': 5432,
     }
@@ -245,12 +245,12 @@ USE_TZ = True
 LOCALE_PATHS = [BASE_DIR / "locale"]
 
 # Email config BACKUP:
-EMAIL_FROM_USER = config('EMAIL_FROM_USER')
-EMAIL_HOST = config('EMAIL_HOST')
-EMAIL_HOST_USER = config('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
-EMAIL_USE_TLS = True
-EMAIL_PORT = 587
+# EMAIL_FROM_USER = config('EMAIL_FROM_USER')
+# EMAIL_HOST = config('EMAIL_HOST')
+# EMAIL_HOST_USER = config('EMAIL_HOST_USER')
+# EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')
+# EMAIL_USE_TLS = True
+# EMAIL_PORT = 587
 
 ######EMAIL_CONFIRMATION_BRANCH is the keyword that needs to be searched
 # EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -6,6 +6,11 @@ import os
 import django_heroku
 
 import dj_database_url
+import environ
+# Initialise environment variables
+env = environ.Env()
+environ.Env.read_env()
+
 from decouple import Csv, config
 
 from django.contrib.messages import constants as messages
@@ -193,10 +198,9 @@ TEMPLATES = [
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'seshat_oct5',
-        'USER': 'postgres',
-        # 'PASSWORD': config('DB_PASSWORD'),
-        'HOST': 'localhost',
+        'NAME': env('NAME'),
+        'USER': env('USER'),
+        'HOST': env('HOST'),
         'PORT': 5432,
     }
 }

--- a/seshat/settings/base.py
+++ b/seshat/settings/base.py
@@ -37,8 +37,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = config(
     "SECRET_KEY", default="django-insecure$seshat.settings.local")
 
-# DEBUG = config("DEBUG", default=True, cast=bool)
-DEBUG = True
+DEBUG = config("DEBUG", default=True, cast=bool)
 
 # if DEBUG:
 #     MY_CURRENT_SERVER = "http://127.0.0.1:8000"

--- a/seshat/settings/local.py
+++ b/seshat/settings/local.py
@@ -1,6 +1,10 @@
 # flake8: noqa
 
 from .base import *
+import environ
+# Initialise environment variables
+env = environ.Env()
+environ.Env.read_env()
 
 #INSTALLED_APPS += ["debug_toolbar"]
 
@@ -12,10 +16,9 @@ from .base import *
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'seshat_oct5',
-        'USER': 'postgres',
-        # 'PASSWORD': config('DB_PASSWORD'),
-        'HOST': 'localhost',
+        'NAME': env('NAME'),
+        'USER': env('USER'),
+        'HOST': env('HOST'),
         'PORT': 5432,
     }
 }

--- a/seshat/settings/local.py
+++ b/seshat/settings/local.py
@@ -11,12 +11,12 @@ from .base import *
 # Databases
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': config('DB_NAME'),
-        'USER': config('DB_USER'),
-        'PASSWORD': config('DB_PASSWORD'),
-        'HOST': config('DB_HOST'),
-        'PORT': '',
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'seshat_oct5',
+        'USER': 'postgres',
+        # 'PASSWORD': config('DB_PASSWORD'),
+        'HOST': 'localhost',
+        'PORT': 5432,
     }
 }
 

--- a/seshat/settings/local.py
+++ b/seshat/settings/local.py
@@ -19,7 +19,7 @@ DATABASES = {
         'NAME': env('NAME'),
         'USER': env('USER'),
         'HOST': env('HOST'),
-        'PORT': 5432,
+        'PORT': env('PORT'),
     }
 }
 


### PR DESCRIPTION
# Changes

- README update
- Removes `backports.zoneinfo` from requirements
- Added a docs folder with a markdown page with the setup instructions that worked for me [see here](https://github.com/edwardchalstrey1/seshat/blob/ed-setup/docs/setup.md)
- Modified the local settings to use a `.env` file with db connection details
- Added a switch in a couple of places so parts of the code that threw errors when running the app locally aren't included. e.g. `EMAIL_FROM_USER = config('EMAIL_FROM_USER')`

# Notes/Qs

Hi @MajidBenam - I've made this PR to the `Qing` branch for now - a couple of questions:

1. Is it worth making  a `develop` branch that we both merge branches into with work that is done but not ready to go live? I'm assuming the `main` branch is what you use on AWS?
2. I imagine I'll spend much of my time working on the spatial data integration specifically, but for other general suggestions and improvements, are you happy for me to just open some issues on this repo?